### PR TITLE
add fix for collision ids, so the TfL ones match stats19

### DIFF
--- a/data/tfl-aliases.csv
+++ b/data/tfl-aliases.csv
@@ -1,8 +1,8 @@
 type,consistent_name,alias
-column,collision_id,AREFNO
-column,collision_id,Accident Ref.
-column,collision_id,Accident Ref
-column,collision_id,_Collision Id
+column,raw_collision_id,AREFNO
+column,raw_collision_id,Accident Ref.
+column,raw_collision_id,Accident Ref
+column,raw_collision_id,_Collision Id
 column,borough,Borough
 column,borough,Borough Name
 column,easting,Easting

--- a/params.yaml
+++ b/params.yaml
@@ -51,7 +51,7 @@
 
   # columns required from raw data
   collision_columns:
-    - collision_id
+    - raw_collision_id
     - borough
     - easting
     - northing
@@ -62,7 +62,7 @@
     - time
 
   casualty_columns:
-    - collision_id
+    - raw_collision_id
     - casualty_id
     - casualty_class
     - number_of_casualties

--- a/src/02-filter-data.py
+++ b/src/02-filter-data.py
@@ -118,7 +118,7 @@ def main():
         casualties['mode_of_travel'] == 'pedal_cycle'
     ]['collision_id'].unique()
 
-    print(f'Filter to cyclist collisiions, {len(cyclist_crash_ids)} crash IDs in data')
+    print(f'Filter to cyclist collisions, {len(cyclist_crash_ids)} crash IDs in data')
 
     collisions = collisions[collisions.collision_id.isin(cyclist_crash_ids)]
     casualties = casualties[casualties.collision_id.isin(cyclist_crash_ids)]


### PR DESCRIPTION
TfL collision IDs from [here](https://tfl.gov.uk/corporate/publications-and-reports/road-safety), did not match the [stats19 ones](https://www.cyclestreets.net/collisions/)

Simple fix to map them.