### PR TITLE
Remove filters + fix stats19 links

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,52 +11,13 @@ st.sidebar.markdown('## Map Options')
 
 form = st.sidebar.form(key='my_form')
 
-tolerance = form.radio(
-    label='Set tolerance for combining junctions in metres (to be removed)',
-    options=[15, 20, 25, 30],
-    index=1
-)
-
-weight_fatal = form.slider(
-    label='Fatal collision weight',
-    min_value=1.,
-    max_value=10.,
-    value=3.,
-    step=.1
-)
-weight_serious = form.slider(
-    label='Serious collision weight',
-    min_value=1.,
-    max_value=10.,
-    value=1.,
-    step=.1
-)
-weight_slight = form.slider(
-    label='Slight collision weight',
-    min_value=0.,
-    max_value=1.,
-    value=0.,
-    step=.01
-)
-
-junctions, collisions, annotations = read_in_data(tolerance)
+junctions, collisions, annotations = read_in_data(tolerance=15)
 
 n_junctions = form.slider(
     label='Number of dangerous junctions to show',
     min_value=0,
     max_value=100,  # not sure we'd ever need to view more then 100?
     value=20
-)
-
-# min_year, max_year = form.slider(
-#     label='Select date period',
-#     min_value=2011,
-#     max_value=2022,
-#     value=(2012, 2022)
-# )
-
-include_slight = form.checkbox(
-    label='Include slight collisions in metric & map'
 )
 
 available_boroughs = sorted(
@@ -80,16 +41,11 @@ else:
     junction_collisions = combine_junctions_and_collisions(
         junctions,
         collisions,
-        boroughs,
-        include_slight,
-        weight_fatal,
-        weight_serious,
-        weight_slight
+        boroughs
     )
     dangerous_junctions = calculate_dangerous_junctions(
         junction_collisions,
-        n_junctions,
-        include_slight
+        n_junctions
     )
 
     if 'ALL' not in boroughs:

--- a/params.yaml
+++ b/params.yaml
@@ -19,10 +19,15 @@
     - unknown
   
   # tolerance level to determine which junctions to combine (in metres)
-  tolerance: 30
+  tolerance: 15
 
   number_of_dangerous_collisions: 100
   distance_to_junction_threshold: .001
+
+  # collision severity weights
+  weight_fatal: 6.8
+  weight_serious: 1.
+  weight_slight: .06
 
   # links to TfL csv data - shame they couldn't have chosen a consistent pattern!!
   data_links:

--- a/src/03-build-junctions-graph.py
+++ b/src/03-build-junctions-graph.py
@@ -124,7 +124,7 @@ def main():
     # read in data params
     params = yaml.load(open("params.yaml", 'r'), Loader=Loader)
 
-    # tolerance = params['tolerance']
+    tolerance = params['tolerance']
 
     # build initial junctions graph
     print('Building initial junction graph')
@@ -141,114 +141,110 @@ def main():
     #     dist=1000
     # )
 
-    # loop through tolerance options.
-    for tolerance in [15, 20, 25, 30]:
-        print(f'tolerance={tolerance}')
+    # simplify graph using the consolidate_intersections()
+    print('Consolidating intersections')
+    G2 = ox.consolidate_intersections(
+        ox.project_graph(G1),
+        tolerance=tolerance,
+        rebuild_graph=True,
+        dead_ends=False,
+        reconnect_edges=True
+    )
 
-        # simplify graph using the consolidate_intersections()
-        print('Consolidating intersections')
-        G2 = ox.consolidate_intersections(
-            ox.project_graph(G1),
-            tolerance=tolerance,
-            rebuild_graph=True,
-            dead_ends=False,
-            reconnect_edges=True
-        )
-
-        # create datafraems from G1 & G2
-        df_lower = (
-            ox.graph_to_gdfs(
-                G1,
-                nodes=True,
-                edges=False,
-                node_geometry=True,
-                fill_edge_geometry=False
-            )
-            .drop(columns=['highway', 'street_count'])
-            .reset_index()
-            .rename(columns={'y': 'lat', 'x': 'lon', 'osmid': 'osmid_original'})
-        )
-
-        df_higher = ox.graph_to_gdfs(
-            G2,
+    # create datafraems from G1 & G2
+    df_lower = (
+        ox.graph_to_gdfs(
+            G1,
             nodes=True,
             edges=False,
             node_geometry=True,
             fill_edge_geometry=False
         )
+        .drop(columns=['highway', 'street_count'])
+        .reset_index()
+        .rename(columns={'y': 'lat', 'x': 'lon', 'osmid': 'osmid_original'})
+    )
+
+    df_higher = ox.graph_to_gdfs(
+        G2,
+        nodes=True,
+        edges=False,
+        node_geometry=True,
+        fill_edge_geometry=False
+    )
 
 
-        # Create hierarchical junction dataframe
-        # 
-        # This needs to store both the lower level junctions (before simplifying) and the higher level.
-        # This is because we want to map collisions to the lower level and then aggregate at the higher level.
-        # 
-        # For this we need to flatten the df_higher dataframe so we can join the datasets.
-        print('Creating junction heirarchy')
+    # Create hierarchical junction dataframe
+    # 
+    # This needs to store both the lower level junctions (before simplifying) and the higher level.
+    # This is because we want to map collisions to the lower level and then aggregate at the higher level.
+    # 
+    # For this we need to flatten the df_higher dataframe so we can join the datasets.
+    print('Creating junction heirarchy')
 
-        df_higher['osmid_original'] = df_higher['osmid_original'].apply(convert_strings_list)
-        df_higher = df_higher.explode('osmid_original')
-        df_higher['osmid_original'] = df_higher['osmid_original'].astype(int)
+    df_higher['osmid_original'] = df_higher['osmid_original'].apply(convert_strings_list)
+    df_higher = df_higher.explode('osmid_original')
+    df_higher['osmid_original'] = df_higher['osmid_original'].astype(int)
 
-        df_higher = (
-            df_higher
-            .reset_index()
-            .drop(columns=['x', 'y', 'street_count', 'highway', 'lon', 'lat'])
-            .rename(columns={'osmid': 'osmid_cluster'})
+    df_higher = (
+        df_higher
+        .reset_index()
+        .drop(columns=['x', 'y', 'street_count', 'highway', 'lon', 'lat'])
+        .rename(columns={'osmid': 'osmid_cluster'})
+    )
+
+    # Combine datasets
+    df = df_lower.merge(
+        df_higher,
+        how='inner',
+        on='osmid_original',
+        suffixes=['_original', '_cluster']
+    )
+
+    # calculate lat, lons for clusters
+    cluster_coords = (
+        df
+        .groupby('osmid_cluster')[['lat', 'lon']]
+        .mean()
+        .reset_index()
+        .rename(columns={'lat': 'latitude_cluster', 'lon': 'longitude_cluster'})
+    )
+
+    # join in
+    df = df.merge(
+        cluster_coords,
+        how='left',
+        on='osmid_cluster'
+    )
+
+    # fill nulls with the lower level coordinate when missing
+    df['latitude_cluster'] = df['latitude_cluster'].fillna(df['lat'])
+    df['longitude_cluster'] = df['longitude_cluster'].fillna(df['lon'])
+
+    # drop some cols and rename some
+    df = (
+        df
+        .drop(
+            columns=['geometry_original', 'geometry_cluster']
         )
-
-        # Combine datasets
-        df = df_lower.merge(
-            df_higher,
-            how='inner',
-            on='osmid_original',
-            suffixes=['_original', '_cluster']
+        .reset_index()
+        .rename(
+            columns={
+                'index': 'junction_index',
+                'lat': 'latitude_junction',
+                'lon': 'longitude_junction',
+                'osmid_original': 'junction_id',
+                'osmid_cluster': 'junction_cluster_id'
+            }
         )
+    )
 
-        # calculate lat, lons for clusters
-        cluster_coords = (
-            df
-            .groupby('osmid_cluster')[['lat', 'lon']]
-            .mean()
-            .reset_index()
-            .rename(columns={'lat': 'latitude_cluster', 'lon': 'longitude_cluster'})
-        )
+    # finally, name junctions
+    print('Naming junctions')
+    df = name_junctions(G1, df)
 
-        # join in
-        df = df.merge(
-            cluster_coords,
-            how='left',
-            on='osmid_cluster'
-        )
-
-        # fill nulls with the lower level coordinate when missing
-        df['latitude_cluster'] = df['latitude_cluster'].fillna(df['lat'])
-        df['longitude_cluster'] = df['longitude_cluster'].fillna(df['lon'])
-
-        # drop some cols and rename some
-        df = (
-            df
-            .drop(
-                columns=['geometry_original', 'geometry_cluster']
-            )
-            .reset_index()
-            .rename(
-                columns={
-                    'index': 'junction_index',
-                    'lat': 'latitude_junction',
-                    'lon': 'longitude_junction',
-                    'osmid_original': 'junction_id',
-                    'osmid_cluster': 'junction_cluster_id'
-                }
-            )
-        )
-
-        # finally, name junctions
-        print('Naming junctions')
-        df = name_junctions(G1, df)
-
-        print(f'Outputing data: data/junctions-tolerance={tolerance}.csv')
-        df.to_csv(f'data/junctions-tolerance={tolerance}.csv', index=False)
+    print(f'Outputing data: data/junctions-tolerance={tolerance}.csv')
+    df.to_csv(f'data/junctions-tolerance={tolerance}.csv', index=False)
 
 
 if __name__ == "__main__":

--- a/src/04-map-collisions-to-graph.py
+++ b/src/04-map-collisions-to-graph.py
@@ -22,80 +22,67 @@ def main():
     # read in data params
     params = yaml.load(open("params.yaml", 'r'), Loader=Loader)
 
-    top_n = params['number_of_dangerous_collisions']
+    tolerance = params['tolerance']
+    # top_n = params['number_of_dangerous_collisions']
     distance_threshold = params['distance_to_junction_threshold']
 
     # read in data
-    # collisions = (
-    #     pd
-    #     .read_csv('data/collision-data/london-crashes.csv')
-    #     .rename(columns={'accident_index': 'id'})
-    # )
-    # collisions = collisions[collisions['max_cyclist_severity'] != 'slight']
+    collisions = (
+        pd
+        .read_csv('data/cycling-collisions.csv')
+        .rename(columns={'collision_id': 'collision_index'})
+    )
 
-    # loop through tolerance options.
-    for tolerance in [15, 20, 25, 30]:
+    junctions = pd.read_csv(f'data/junctions-tolerance={tolerance}.csv', low_memory=False)
 
-        print(f'tolerance={tolerance}')
+    # Find nearest junction to each collision
+    # Use BallTree algorithm.
+    # Havesine distance since these are coordinates.
 
-        # read in data
-        collisions = (
-            pd
-            .read_csv('data/cycling-collisions.csv')
-            .rename(columns={'collision_id': 'collision_index'})
-        )
-        # collisions = collisions[collisions['max_cyclist_severity'] != 'slight']
+    print('Finding nearest junction to each collision')
+    tree = BallTree(junctions[['latitude_junction', 'longitude_junction']], metric='haversine')
 
-        junctions = pd.read_csv(f'data/junctions-tolerance={tolerance}.csv', low_memory=False)
+    collisions[['distance_to_junction', 'junction_index']] = collisions.apply(
+        lambda row: get_nearest_junction(row, tree), axis=1, result_type='expand'
+    )
 
-        # Find nearest junction to each collision
-        # Use BallTree algorithm.
-        # Havesine distance since these are coordinates.
+    # join to get junction ids
+    collisions = collisions.merge(
+        junctions[['junction_index', 'junction_id']],
+        how='left',
+        on='junction_index'
+    )
 
-        print('Finding nearest junction to each collision')
-        tree = BallTree(junctions[['latitude_junction', 'longitude_junction']], metric='haversine')
-
-        collisions[['distance_to_junction', 'junction_index']] = collisions.apply(
-            lambda row: get_nearest_junction(row, tree), axis=1, result_type='expand'
-        )
-
-        # join to get junction ids
-        collisions = collisions.merge(
-            junctions[['junction_index', 'junction_id']],
+    # combine datasets
+    junction_collisions = (
+        junctions
+        .merge(
+            collisions,
             how='left',
-            on='junction_index'
+            on=['junction_id', 'junction_index']
         )
+    )
 
-        # combine datasets
-        junction_collisions = (
-            junctions
-            .merge(
-                collisions,
-                how='left',
-                on=['junction_id', 'junction_index']
-            )
-        )
+    # filter to those within certain distance
+    junction_collisions = junction_collisions[
+        junction_collisions['distance_to_junction'] <= distance_threshold
+    ]
+    collisions = collisions[
+        collisions['distance_to_junction'] <= distance_threshold
+    ]
 
-        # filter to those within certain distance
-        junction_collisions = junction_collisions[
-            junction_collisions['distance_to_junction'] <= distance_threshold
-        ]
-        collisions = collisions[
-            collisions['distance_to_junction'] <= distance_threshold
-        ]
+    # junction_stats = (
+    #     junction_collisions
+    #     .groupby(['junction_cluster_id', 'latitude_cluster', 'longitude_cluster'])
+    #     .agg({'recency_danger_metric': 'sum', 'slight_cyclist_casualties': 'sum'})
+    #     .sort_values(by='recency_danger_metric', ascending=False)
+    #     .head(top_n)
+    #     .reset_index()
+    # )
 
-        # junction_stats = (
-        #     junction_collisions
-        #     .groupby(['junction_cluster_id', 'latitude_cluster', 'longitude_cluster'])
-        #     .agg({'recency_danger_metric': 'sum', 'slight_cyclist_casualties': 'sum'})
-        #     .sort_values(by='recency_danger_metric', ascending=False)
-        #     .head(top_n)
-        #     .reset_index()
-        # )
-
-        # output data
-        # junction_stats.to_csv(f'data/dangerous-junctions-tolerance={tolerance}.csv', index=False)
-        collisions.to_csv(f'data/collisions-tolerance={tolerance}.csv', index=False)
+    # output data
+    # junction_stats.to_csv(f'data/dangerous-junctions-tolerance={tolerance}.csv', index=False)
+    collisions.to_csv(f'data/collisions-tolerance={tolerance}.csv', index=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Removes the following app filters:
- Tolerance - this is now set to 15m
- Severity weights - these are set to 6.8 for fatal, 1 for serious, .06 for slight

Fix stats19 urls, which had a ".0" at the end. This was because the `collision_index` field wasn't an integer. They should work now.