### PR TITLE
Tweak collision metric

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ col1, col2 = st.columns([10, 2])
 with col1:
     st.markdown('# Dangerous Junctions App')
 with col2:
-    st.image(st.secrets['logo'], width=200)
+    st.image('./img/LCC_logo_horizontal_red.png', width=200)
 
 
 st.sidebar.markdown('### Map Options')


### PR DESCRIPTION
Only use worst severity casualty from each collision to count towards overall metric. So, for example a collision with 1 fatal and 1 serious collision, only the fatal counts towards metric.