### PR TITLE
Remove annotation layer

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ st.markdown(
 # st.write('<style>div.block-container{padding-top:2rem;}</style>', unsafe_allow_html=True)
 
 
-junctions, collisions, annotations, notes = read_in_data(tolerance=15)
+junctions, collisions, notes = read_in_data(tolerance=15)
 
 with st.expander("### App settings", expanded=True):
 
@@ -98,17 +98,15 @@ else:
         casualty_type
     )
 
-    if 'ALL' not in boroughs:
-        filtered_annotations = annotations[annotations['borough'].isin(boroughs)]
-    else:
-        filtered_annotations = annotations
-
     # set default to worst junction...
-    if 'chosen_point' not in st.session_state:
+    if ('chosen_point' not in st.session_state):
+        st.session_state['chosen_point'] = dangerous_junctions[['latitude_cluster', 'longitude_cluster']].values[0]
+    elif casualty_type != st.session_state['previous_casualty_type']:
         st.session_state['chosen_point'] = dangerous_junctions[['latitude_cluster', 'longitude_cluster']].values[0]
     elif boroughs != st.session_state['previous_boroughs']:
         st.session_state['chosen_point'] = dangerous_junctions[['latitude_cluster', 'longitude_cluster']].values[0]
 
+    st.session_state['previous_casualty_type'] = casualty_type
     st.session_state['previous_boroughs'] = boroughs
 
     col1, col2 = st.columns([6, 6])
@@ -123,23 +121,13 @@ else:
             Map shows the {n_junctions} most dangerous junctions in {borough_msg}.
         ''')
 
-        high_map = high_level_map(dangerous_junctions, junction_collisions, filtered_annotations, n_junctions)
+        high_map = high_level_map(dangerous_junctions, junction_collisions, n_junctions)
         map_click = st_folium(
             high_map,
             returned_objects=['last_object_clicked'],
             use_container_width=True,
             height=550
         )
-
-        if map_click['last_object_clicked']:
-            if len(annotations[
-                    (annotations['latitude'] == map_click['last_object_clicked']['lat']) &
-                    (annotations['longitude'] == map_click['last_object_clicked']['lng'])
-            ]) == 0:
-                st.session_state['chosen_point'] = [
-                    map_click['last_object_clicked']['lat'],
-                    map_click['last_object_clicked']['lng']
-                ]
 
     with col2:
         st.markdown('''

--- a/src/app_functions.py
+++ b/src/app_functions.py
@@ -42,10 +42,9 @@ def read_in_data(tolerance: int) -> tuple:
             dtype={'collision_index': int}
         )
 
-    map_annotations = pd.read_csv(st.secrets["map_annotations"])
     junction_notes = pd.read_csv(st.secrets["junction_notes"])
 
-    return junctions, collisions, map_annotations, junction_notes
+    return junctions, collisions, junction_notes
 
 
 @st.cache_data(show_spinner=False)
@@ -314,7 +313,7 @@ def get_low_level_junction_data(junction_collisions: pd.DataFrame, chosen_point:
     return low_junction_collisions
 
 
-def high_level_map(dangerous_junctions: pd.DataFrame, map_data: pd.DataFrame, annotations: pd.DataFrame, n_junctions: int) -> folium.Map:
+def high_level_map(dangerous_junctions: pd.DataFrame, map_data: pd.DataFrame, n_junctions: int) -> folium.Map:
     """
     Function to generate the junction map
 
@@ -336,38 +335,6 @@ def high_level_map(dangerous_junctions: pd.DataFrame, map_data: pd.DataFrame, an
     ]
 
     pal = get_html_colors(n_junctions)
-
-    # add annotation layer
-    cols = ['latitude', 'longitude', 'map_label', 'colour']
-    for lat, lon, label, colour in annotations[cols].values:
-        iframe = folium.IFrame(
-            html='''
-                <style>
-                body {
-                  font-family: Tahoma, sans-serif;
-                  font-size: 12px;
-                }
-                </style>
-            ''' + label,
-            width=200,
-            height=80
-        )
-        folium.CircleMarker(
-            location=[lat, lon],
-            radius=4,    
-            color=colour,
-            fill_color=colour,
-            fill_opacity=1,
-        ).add_to(m)
-        folium.Marker(
-            location=[lat, lon],
-            popup=folium.Popup(iframe),
-            icon=DivIcon(
-                icon_size=(30,30),
-                icon_anchor=(3,7),
-                html='<div style="font-size: 7pt; font-family: monospace; color: white">I</div>',
-            ),
-        ).add_to(m)
 
     # add junction markers
     cols = ['latitude_cluster', 'longitude_cluster', 'label', 'junction_rank']


### PR DESCRIPTION
This was taking up too much map real estate and has been superseeded by the ability to add notes to junctions pop-ups.