### PR TITLE
*FIX* Enable outside development

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The current method used to identify dangerous junctions works as follows:
 To run and develop on this code:
 - Clone the repo
 - Make sure Python installed
-- Setup a virtual environment, e.g: ```python3 -m venv venv```
+- Setup a virtual environment, e.g: ```python3.8 -m venv venv```
+  - nb. the dependency `backports.zoneinfo` requires python version of max 3.8, see [docs](https://pypi.org/project/backports.zoneinfo/)
 - Activate the virtual environment: `source venv/bin/activate`
 - Install the packages using: `pip install -r requirements.txt`
 - Run the following:


### PR DESCRIPTION
**Context:**
I'd like to replicate this work for other cities around the country using the dft published data instead of tfl, so cloned and tried to run the app. There were some issues specific to the original developer's machine/cloud access so it wouldn't run immediately.

**Changes:**
- added `ENVIRONMENT` variable to make the dev environment universal. NB. This would mean that `ENVIRONMENT=prod` would need to be added on the production server
- moved gc connection so it isn't called when running locally
- added try/except to handle missing `.streamlit/secrets.toml` file, I think this only relates to manual notes on junctions.
- `params` -> `DATA_PARAMETERS`, params was shadowed from outer scope

**Tests:**
I've run the app locally and it works for me