### PR TITLE
extract css, fix banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,56 +7,21 @@ from streamlit_folium import st_folium
 
 st.set_page_config(layout='wide')
 
+# apply css styling
+with open('./css/style.css') as f:
+    st.markdown(f'<style>{f.read()}</style>', unsafe_allow_html=True)
+
 st.markdown(
     """
-        <header class="css-18ni7ap ezrtsby2" tabindex="-1" data-testid=""stHeader="">
-        <div class="header" style="background-color:#FFFFFF;">
+        <header class="css-18ni7ap ezrtsby2" tabindex="-1">
+        <div class="header">
         <a href="https://lcc.org.uk/">
-        <img src="https://lcc.org.uk/wp-content/themes/lcc/src/img/svgs/logo-white.svg" alt="London Cycling Campaign logo" class="logo" style="max-width:20%;">
+        <img src="https://lcc.org.uk/wp-content/themes/lcc/src/img/svgs/logo-white.svg" alt="London Cycling Campaign logo" class="logo">
         </a>
         <h1 class="title">Dangerous <br/> Junctions Tool</h1>
         </div>
         </header>
     """,
-    unsafe_allow_html=True
-)
-
-st.write('<style>div.block-container{padding-top:0rem;}</style>', unsafe_allow_html=True)
-
-st.markdown(
-    '''
-        <style>
-        .header img {
-        position: fixed;
-        top: 0px;
-        left: 0px;
-        height: 6.5rem;
-        z-index: 999991;
-        background-color: #e30613;
-        border: 1.5vw solid #e30613;
-        }
-        .header h1 {
-        position: relative;
-        top: -10px;
-        height: 6.5rem; 
-        text-align: center;
-        vertical-align: middle;
-        font-size: 2em;
-        z-index: 999991;
-        }
-        </style> 
-    ''',
-    unsafe_allow_html=True
-)
-
-
-# this is basically so you can scroll past the maps on mobile & to tighten header
-st.write(
-    '''
-    <style>div.block-container{padding-top:0rem;}</style>
-    <style>div.block-container{padding-left:1rem;}</style>
-    <style>div.block-container{padding-right:1rem;}</style>
-    ''',
     unsafe_allow_html=True
 )
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,33 @@
+/* sets the size, position and colour of the LCC logo */
+.header img {
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    height: 6.5rem;
+    max-width: 20%;
+    z-index: 999991;
+    background-color: #e30613;
+    border: 1.5vw solid #e30613;
+}
+
+/* sets the position of the title */
+.header h1 {
+    position: fixed;
+    top: -10px;
+    text-align: center;
+    height: 6.5rem;
+    width: 100%;
+    z-index: 999991;
+    font-size: 2em;
+}
+
+/* extends the height of the base streamlit header to match headers above */
+.st-emotion-cache-18ni7ap {
+height: 6.5rem;
+}
+
+/* allows you to scroll past the maps on mobile / small screen devices */
+div.block-container{
+    padding-left:1rem;
+    padding-right:1rem;
+}

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,6 @@ pympler
 pyyaml
 scikit-learn
 seaborn
-streamlit==1.32.1
+streamlit==1.32.2
 streamlit_folium
 st-files-connection

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ idna==3.4
     # via
     #   requests
     #   yarl
-importlib-metadata==7.1.0
+importlib-metadata==6.11.0
     # via
     #   build
     #   fiona
@@ -266,7 +266,7 @@ smmap==5.0.0
     # via gitdb
 st-files-connection==0.1.0
     # via -r requirements.in
-streamlit==1.32.1
+streamlit==1.32.2
     # via
     #   -r requirements.in
     #   st-files-connection


### PR DESCRIPTION
Upgrading to streamlit 1.32 broke the header for some reason. This fixes it and extracts the css as it was getting a bit messy in the app.py file.