### PR TITLE
2025 app launch

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,9 +35,8 @@ def open_pop_up():
         improvements to road networks in London, helping make junctions
         safer for both cyclists and pedestrians.
 
-        *__New for 2024:__*
-        - Data now covers 2019 to 2023
-        - Slightly adjusted fatal, serious & slight collision weights (see 'About this app')
+        *__New for 2025:__*
+        - Data now covers 2019 to 2024
     """)
 
 if 'pop_up_opened' not in st.session_state:
@@ -238,7 +237,7 @@ with st.expander("About this app"):
                  
             The collision data is sourced from the TfL collision extracts,
             which can be [accessed here](https://tfl.gov.uk/corporate/publications-and-reports/road-safety) and includes all
-            collisions involving a cyclist or pedestrian from 2019 to 2023. The junction data is generated using the
+            collisions involving a cyclist or pedestrian from 2020 to 2024. The junction data is generated using the
             [OSMnx package](https://github.com/gboeing/osmnx) that relies on OpenStreetMap data.
                 
             ##### Contact
@@ -259,7 +258,7 @@ with st.expander("About this app"):
             3. Map each collision to its nearest junction based on coordinate data
             4. Assign each collision a 'danger metric' value based on the severity of the worst
             casualty involved (`5` for fatal, `1` for severe & `.1` for slight) and weight this by 
-            how recent the collision was (`1` for 2023 down to `.78` for 2019)
+            how recent the collision was (`1` for 2024 down to `.78` for 2020)
             5. Aggregate the individual danger metrics across each junction to get an overall
             danger metric value for each junction
             6. Rank junctions from most to least dangerous based on this value

--- a/data/tfl-aliases.csv
+++ b/data/tfl-aliases.csv
@@ -25,6 +25,8 @@ column,casualty_severity,Casualty Severity
 column,casualty_severity,_Casualty Severity
 column,mode_of_travel,Casualty Mode of Travel
 column,mode_of_travel,Mode of Travel
+column,casualty_gender,Casualty Gender
+column,casualty_gender,Casualty Sex
 value,fatal,1 FATAL
 value,fatal,1 Fatal
 value,fatal,Fatal
@@ -99,3 +101,6 @@ value,other_vehicle,8 Other Vehicle
 value,other_vehicle,Other Vehicle
 value,private_hire,9 PRIVATE HIRE
 value,private_hire,Private Hire
+value,Male,1 MALE
+value,Female,2 FEMALE
+value,Unknown,'-1 UNKNOWN

--- a/data/tfl-aliases.csv
+++ b/data/tfl-aliases.csv
@@ -33,6 +33,9 @@ value,fatal,Fatal
 value,serious,2 SERIOUS
 value,serious,2 Serious
 value,serious,Serious
+value,serious,Less Serious
+value,serious,Moderately Serious
+value,serious,Very Serious
 value,slight,3 Slight
 value,slight,3 SLIGHT
 value,slight,Slight

--- a/notebooks/collision-stats.ipynb
+++ b/notebooks/collision-stats.ipynb
@@ -1,0 +1,970 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Collision stats\n",
+    "\n",
+    "__May 2025__\n",
+    "\n",
+    "Answering 2 key questions:\n",
+    "- What fraction of serious or fatal collisions happen at a junction?\n",
+    "- What fraction of casualties are female?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "import pandas as pd\n",
+    "\n",
+    "from yaml import Loader"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q1 - What fraction of serious or fatal collisions happen at a junction?\n",
+    "\n",
+    "This data has the junction filter removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Junction types:\n",
+      "['roundabout', 'mini_roundabout', 't_or_staggered_junction', 'slip_road', 'crossroads', 'multi_junction', 'other_junction', 'unknown']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>raw_collision_id</th>\n",
+       "      <th>borough</th>\n",
+       "      <th>easting</th>\n",
+       "      <th>northing</th>\n",
+       "      <th>location</th>\n",
+       "      <th>collision_severity</th>\n",
+       "      <th>junction_detail</th>\n",
+       "      <th>date</th>\n",
+       "      <th>time</th>\n",
+       "      <th>year</th>\n",
+       "      <th>...</th>\n",
+       "      <th>serious_cyclist_casualties</th>\n",
+       "      <th>slight_cyclist_casualties</th>\n",
+       "      <th>max_cyclist_severity</th>\n",
+       "      <th>fatal_pedestrian_casualties</th>\n",
+       "      <th>serious_pedestrian_casualties</th>\n",
+       "      <th>slight_pedestrian_casualties</th>\n",
+       "      <th>max_pedestrian_severity</th>\n",
+       "      <th>recency_weight</th>\n",
+       "      <th>is_cyclist_collision</th>\n",
+       "      <th>is_pedestrian_collision</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1230419171</td>\n",
+       "      <td>MERTON</td>\n",
+       "      <td>525060.0</td>\n",
+       "      <td>170416.0</td>\n",
+       "      <td>ON GLADSTONE ROAD, NEAR THE JUNCTION WITH SIR ...</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>other_junction</td>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>01:24:00</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1230419191</td>\n",
+       "      <td>BARNET</td>\n",
+       "      <td>520341.0</td>\n",
+       "      <td>190175.0</td>\n",
+       "      <td>ON BURNT OAK BROADWAY, NEAR THE JUNCTION WITH ...</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>t_or_staggered_junction</td>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>02:13:00</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1230419198</td>\n",
+       "      <td>BRENT</td>\n",
+       "      <td>524780.0</td>\n",
+       "      <td>184471.0</td>\n",
+       "      <td>ON KILBURN HIGH ROAD, 30 METRES SOUTH OF THE J...</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>no_junction_in_20m</td>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>02:10:00</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1230419201</td>\n",
+       "      <td>SOUTHWARK</td>\n",
+       "      <td>532189.0</td>\n",
+       "      <td>179517.0</td>\n",
+       "      <td>ON BOROUGH ROAD, NEAR THE JUNCTION WITH BOROUG...</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>crossroads</td>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>03:00:00</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1230419209</td>\n",
+       "      <td>HARINGEY</td>\n",
+       "      <td>533656.0</td>\n",
+       "      <td>188929.0</td>\n",
+       "      <td>ON HIGH ROAD, 28 METRES NORTH OF THE JUNCTION ...</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>no_junction_in_20m</td>\n",
+       "      <td>2023-01-01</td>\n",
+       "      <td>07:23:00</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 24 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   raw_collision_id    borough   easting  northing  \\\n",
+       "0        1230419171     MERTON  525060.0  170416.0   \n",
+       "1        1230419191     BARNET  520341.0  190175.0   \n",
+       "2        1230419198      BRENT  524780.0  184471.0   \n",
+       "3        1230419201  SOUTHWARK  532189.0  179517.0   \n",
+       "4        1230419209   HARINGEY  533656.0  188929.0   \n",
+       "\n",
+       "                                            location collision_severity  \\\n",
+       "0  ON GLADSTONE ROAD, NEAR THE JUNCTION WITH SIR ...             slight   \n",
+       "1  ON BURNT OAK BROADWAY, NEAR THE JUNCTION WITH ...             slight   \n",
+       "2  ON KILBURN HIGH ROAD, 30 METRES SOUTH OF THE J...             slight   \n",
+       "3  ON BOROUGH ROAD, NEAR THE JUNCTION WITH BOROUG...             slight   \n",
+       "4  ON HIGH ROAD, 28 METRES NORTH OF THE JUNCTION ...             slight   \n",
+       "\n",
+       "           junction_detail        date      time  year  ...  \\\n",
+       "0           other_junction  2023-01-01  01:24:00  2023  ...   \n",
+       "1  t_or_staggered_junction  2023-01-01  02:13:00  2023  ...   \n",
+       "2       no_junction_in_20m  2023-01-01  02:10:00  2023  ...   \n",
+       "3               crossroads  2023-01-01  03:00:00  2023  ...   \n",
+       "4       no_junction_in_20m  2023-01-01  07:23:00  2023  ...   \n",
+       "\n",
+       "   serious_cyclist_casualties  slight_cyclist_casualties  \\\n",
+       "0                         NaN                        NaN   \n",
+       "1                         0.0                        1.0   \n",
+       "2                         NaN                        NaN   \n",
+       "3                         0.0                        1.0   \n",
+       "4                         NaN                        NaN   \n",
+       "\n",
+       "   max_cyclist_severity  fatal_pedestrian_casualties  \\\n",
+       "0                   NaN                          0.0   \n",
+       "1                slight                          NaN   \n",
+       "2                   NaN                          0.0   \n",
+       "3                slight                          NaN   \n",
+       "4                   NaN                          0.0   \n",
+       "\n",
+       "   serious_pedestrian_casualties  slight_pedestrian_casualties  \\\n",
+       "0                            0.0                           1.0   \n",
+       "1                            NaN                           NaN   \n",
+       "2                            0.0                           1.0   \n",
+       "3                            NaN                           NaN   \n",
+       "4                            0.0                           1.0   \n",
+       "\n",
+       "  max_pedestrian_severity  recency_weight  is_cyclist_collision  \\\n",
+       "0                  slight             1.0                 False   \n",
+       "1                     NaN             1.0                  True   \n",
+       "2                  slight             1.0                 False   \n",
+       "3                     NaN             1.0                  True   \n",
+       "4                  slight             1.0                 False   \n",
+       "\n",
+       "   is_pedestrian_collision  \n",
+       "0                     True  \n",
+       "1                    False  \n",
+       "2                     True  \n",
+       "3                    False  \n",
+       "4                     True  \n",
+       "\n",
+       "[5 rows x 24 columns]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = yaml.load(open(\"../params.yaml\", 'r'), Loader=Loader)\n",
+    "df = pd.read_csv('../data/pedestrian-and-cyclist-collisions-all.csv')\n",
+    "\n",
+    "print('Junction types:')\n",
+    "print(params['valid_junction_types'])\n",
+    "\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Percentage of serious or fatal collisions at a junction?\n",
+    "\n",
+    "Cyclist and last 5 years."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "77.75603392041748"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mask = (\n",
+    "    df['is_cyclist_collision']\n",
+    "    &\n",
+    "    ((df['max_cyclist_severity'] == 'serious') | (df['max_cyclist_severity'] == 'fatal'))\n",
+    ")\n",
+    "\n",
+    "(\n",
+    "    df[mask & df['junction_detail'].isin(params['valid_junction_types'])]\n",
+    "    .raw_collision_id.nunique()\n",
+    "    /\n",
+    "    df[mask].raw_collision_id.nunique()\n",
+    ") * 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Above, but cut by year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "year\n",
+       "2019    75.515464\n",
+       "2020    77.739331\n",
+       "2021    76.653307\n",
+       "2022    79.060665\n",
+       "2023    79.380342\n",
+       "Name: raw_collision_id, dtype: float64"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# check the trend\n",
+    "(\n",
+    "    df[mask & df['junction_detail'].isin(params['valid_junction_types'])].groupby('year')['raw_collision_id'].nunique()\n",
+    "    /\n",
+    "    df[mask].groupby('year')['raw_collision_id'].nunique()\n",
+    "    *\n",
+    "    100\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Finally, do the stats move much if we filter out unknown?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "74.40747988693194"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# exclude unknown\n",
+    "junction_types = [\n",
+    "    'roundabout', 'mini_roundabout', 't_or_staggered_junction',\n",
+    "    'slip_road', 'crossroads', 'multi_junction', 'other_junction'\n",
+    "]\n",
+    "\n",
+    "(\n",
+    "    df[mask & df['junction_detail'].isin(junction_types)]\n",
+    "    .raw_collision_id.nunique()\n",
+    "    /\n",
+    "    df[mask].raw_collision_id.nunique()\n",
+    ") * 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Q2 - What fraction of casualties are female?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>raw_collision_id</th>\n",
+       "      <th>casualty_id</th>\n",
+       "      <th>casualty_class</th>\n",
+       "      <th>casualty_gender</th>\n",
+       "      <th>number_of_casualties</th>\n",
+       "      <th>casualty_severity</th>\n",
+       "      <th>mode_of_travel</th>\n",
+       "      <th>collision_id</th>\n",
+       "      <th>year</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1230419171</td>\n",
+       "      <td>1</td>\n",
+       "      <td>pedestrian</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>1</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>pedestrian</td>\n",
+       "      <td>2023010419171</td>\n",
+       "      <td>2023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1230419183</td>\n",
+       "      <td>1</td>\n",
+       "      <td>driver_or_rider</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>1</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>car</td>\n",
+       "      <td>2023010419183</td>\n",
+       "      <td>2023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1230419183</td>\n",
+       "      <td>2</td>\n",
+       "      <td>passenger</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>1</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>car</td>\n",
+       "      <td>2023010419183</td>\n",
+       "      <td>2023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1230419189</td>\n",
+       "      <td>1</td>\n",
+       "      <td>driver_or_rider</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>1</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>car</td>\n",
+       "      <td>2023010419189</td>\n",
+       "      <td>2023</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1230419191</td>\n",
+       "      <td>1</td>\n",
+       "      <td>driver_or_rider</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>1</td>\n",
+       "      <td>slight</td>\n",
+       "      <td>pedal_cycle</td>\n",
+       "      <td>2023010419191</td>\n",
+       "      <td>2023</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   raw_collision_id  casualty_id   casualty_class casualty_gender  \\\n",
+       "0        1230419171            1       pedestrian          Female   \n",
+       "1        1230419183            1  driver_or_rider            Male   \n",
+       "2        1230419183            2        passenger          Female   \n",
+       "3        1230419189            1  driver_or_rider            Male   \n",
+       "4        1230419191            1  driver_or_rider            Male   \n",
+       "\n",
+       "   number_of_casualties casualty_severity mode_of_travel   collision_id  year  \n",
+       "0                     1            slight     pedestrian  2023010419171  2023  \n",
+       "1                     1            slight            car  2023010419183  2023  \n",
+       "2                     1            slight            car  2023010419183  2023  \n",
+       "3                     1            slight            car  2023010419189  2023  \n",
+       "4                     1            slight    pedal_cycle  2023010419191  2023  "
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "casualties = pd.read_csv('../data/casualties.csv')\n",
+    "casualties['year'] = casualties['collision_id'].apply(lambda x: int(str(x)[0:4]))\n",
+    "\n",
+    "casualties.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "casualty_mask = casualties['mode_of_travel'] == 'pedal_cycle'\n",
+    "severity_mask = (\n",
+    "    (casualties['casualty_severity'] == 'serious') |\n",
+    "    (casualties['casualty_severity'] == 'fatal')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### % Female, for all severities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "casualty_gender\n",
+       "Female      5632\n",
+       "Male       18497\n",
+       "Unknown      464\n",
+       "Name: raw_collision_id, dtype: int64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "casualty_gender\n",
+       "Female     22.900825\n",
+       "Male       75.212459\n",
+       "Unknown     1.886716\n",
+       "Name: raw_collision_id, dtype: float64"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "display(\n",
+    "    casualties[casualty_mask].groupby('casualty_gender')['raw_collision_id'].count()\n",
+    ")\n",
+    "\n",
+    "(\n",
+    "    casualties[casualty_mask]\n",
+    "    .groupby('casualty_gender')['raw_collision_id']\n",
+    "    .count()\n",
+    "    /\n",
+    "    casualties[casualty_mask]['raw_collision_id']\n",
+    "    .count()\n",
+    "    *\n",
+    "    100\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Above, but broken down by year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>casualty_gender</th>\n",
+       "      <th>Female</th>\n",
+       "      <th>Male</th>\n",
+       "      <th>Unknown</th>\n",
+       "      <th>%_female</th>\n",
+       "      <th>%_male</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>year</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2019</th>\n",
+       "      <td>1140</td>\n",
+       "      <td>3441</td>\n",
+       "      <td>53</td>\n",
+       "      <td>0.246008</td>\n",
+       "      <td>0.742516</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020</th>\n",
+       "      <td>1140</td>\n",
+       "      <td>3586</td>\n",
+       "      <td>63</td>\n",
+       "      <td>0.238046</td>\n",
+       "      <td>0.748762</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021</th>\n",
+       "      <td>1194</td>\n",
+       "      <td>3971</td>\n",
+       "      <td>112</td>\n",
+       "      <td>0.226265</td>\n",
+       "      <td>0.752479</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2022</th>\n",
+       "      <td>1124</td>\n",
+       "      <td>3855</td>\n",
+       "      <td>112</td>\n",
+       "      <td>0.220782</td>\n",
+       "      <td>0.757186</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2023</th>\n",
+       "      <td>1034</td>\n",
+       "      <td>3644</td>\n",
+       "      <td>124</td>\n",
+       "      <td>0.215327</td>\n",
+       "      <td>0.758816</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "casualty_gender  Female  Male  Unknown  %_female    %_male\n",
+       "year                                                      \n",
+       "2019               1140  3441       53  0.246008  0.742516\n",
+       "2020               1140  3586       63  0.238046  0.748762\n",
+       "2021               1194  3971      112  0.226265  0.752479\n",
+       "2022               1124  3855      112  0.220782  0.757186\n",
+       "2023               1034  3644      124  0.215327  0.758816"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gender_by_year = (\n",
+    "    casualties[casualty_mask]\n",
+    "    .groupby(['year', 'casualty_gender'])\n",
+    "    ['raw_collision_id']\n",
+    "    .count()\n",
+    "    .reset_index(name='count')\n",
+    "    .pivot(columns='casualty_gender', index='year', values='count')\n",
+    ")\n",
+    "\n",
+    "gender_by_year['%_female'] = gender_by_year['Female'] / gender_by_year.sum(axis=1)\n",
+    "gender_by_year['%_male'] = gender_by_year['Male'] / gender_by_year.sum(axis=1)\n",
+    "\n",
+    "gender_by_year"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### % Female, for serious or fatal"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "casualty_gender\n",
+       "Female     1072\n",
+       "Male       3529\n",
+       "Unknown      12\n",
+       "Name: raw_collision_id, dtype: int64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "casualty_gender\n",
+       "Female     23.238673\n",
+       "Male       76.501192\n",
+       "Unknown     0.260134\n",
+       "Name: raw_collision_id, dtype: float64"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "display(\n",
+    "    casualties[casualty_mask & severity_mask].groupby('casualty_gender')['raw_collision_id'].count()\n",
+    ")\n",
+    "\n",
+    "(\n",
+    "    casualties[casualty_mask & severity_mask]\n",
+    "    .groupby('casualty_gender')['raw_collision_id']\n",
+    "    .count()\n",
+    "    /\n",
+    "    casualties[casualty_mask & severity_mask]['raw_collision_id']\n",
+    "    .count()\n",
+    "    *\n",
+    "    100\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Above, but broken down by year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>casualty_gender</th>\n",
+       "      <th>Female</th>\n",
+       "      <th>Male</th>\n",
+       "      <th>Unknown</th>\n",
+       "      <th>%_female</th>\n",
+       "      <th>%_male</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>year</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2019</th>\n",
+       "      <td>175</td>\n",
+       "      <td>602</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.224936</td>\n",
+       "      <td>0.773555</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2020</th>\n",
+       "      <td>209</td>\n",
+       "      <td>658</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.240783</td>\n",
+       "      <td>0.757854</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2021</th>\n",
+       "      <td>238</td>\n",
+       "      <td>758</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.238238</td>\n",
+       "      <td>0.758578</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2022</th>\n",
+       "      <td>234</td>\n",
+       "      <td>789</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0.227848</td>\n",
+       "      <td>0.768087</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2023</th>\n",
+       "      <td>216</td>\n",
+       "      <td>722</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.229543</td>\n",
+       "      <td>0.767082</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "casualty_gender  Female  Male  Unknown  %_female    %_male\n",
+       "year                                                      \n",
+       "2019                175   602        1  0.224936  0.773555\n",
+       "2020                209   658        1  0.240783  0.757854\n",
+       "2021                238   758        3  0.238238  0.758578\n",
+       "2022                234   789        4  0.227848  0.768087\n",
+       "2023                216   722        3  0.229543  0.767082"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gender_by_year = (\n",
+    "    casualties[casualty_mask & severity_mask]\n",
+    "    .groupby(['year', 'casualty_gender'])\n",
+    "    ['raw_collision_id']\n",
+    "    .count()\n",
+    "    .reset_index(name='count')\n",
+    "    .pivot(columns='casualty_gender', index='year', values='count')\n",
+    ")\n",
+    "\n",
+    "gender_by_year['%_female'] = gender_by_year['Female'] / gender_by_year.sum(axis=1)\n",
+    "gender_by_year['%_male'] = gender_by_year['Male'] / gender_by_year.sum(axis=1)\n",
+    "\n",
+    "gender_by_year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "casualties[casualty_mask].to_csv('../data/cyclist_casualties.csv', index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/params.yaml
+++ b/params.yaml
@@ -58,6 +58,7 @@
     - raw_collision_id
     - casualty_id
     - casualty_class
+    - casualty_gender
     - number_of_casualties
     - casualty_severity
     - mode_of_travel

--- a/params.yaml
+++ b/params.yaml
@@ -29,6 +29,8 @@
 
   # links to TfL csv data - shame they couldn't have chosen a consistent pattern!!
   data_links:
+    - "https://content.tfl.gov.uk/jan-dec-2024-gla-data-extract-casualty.csv"
+    - "https://content.tfl.gov.uk/jan-dec-2024-gla-data-extract-attendant.csv"
     - "https://content.tfl.gov.uk/jan-dec-2023-gla-data-extract-casualty.csv"
     - "https://content.tfl.gov.uk/jan-dec-2023-gla-data-extract-attendant.csv"
     - "https://content.tfl.gov.uk/jan-dec-2022-gla-data-extract-casualties.csv"
@@ -37,10 +39,8 @@
     - "https://content.tfl.gov.uk/jan-dec-2021-gla-data-extract-attendant.csv"
     - "https://content.tfl.gov.uk/2020-gla-data-extract-casualty.csv"
     - "https://content.tfl.gov.uk/2020-gla-data-extract-attendant.csv"
-    - "https://content.tfl.gov.uk/2019-gla-data-extract-attendant.csv"
-    - "https://content.tfl.gov.uk/2019-gla-data-extract-casualty.csv"
-    # - "https://content.tfl.gov.uk/2018-data-files-casualty.csv"
-    # - "https://content.tfl.gov.uk/2018-data-files-attendant.csv"
+    # - "https://content.tfl.gov.uk/2019-gla-data-extract-attendant.csv"
+    # - "https://content.tfl.gov.uk/2019-gla-data-extract-casualty.csv"
 
   # columns required from raw data
   collision_columns:

--- a/src/01-download-tfl-data.py
+++ b/src/01-download-tfl-data.py
@@ -151,6 +151,9 @@ def correct_data(df: pd.DataFrame, corrections: dict) -> pd.DataFrame:
 
 
 def main():
+    # supress .replace() warnings
+    pd.set_option('future.no_silent_downcasting', True)
+
     params = yaml.load(open("params.yaml", 'r'), Loader=Loader)
     data_corrections = yaml.load(open("data_corrections.yaml", 'r'), Loader=Loader)
 
@@ -193,7 +196,7 @@ def main():
         format='%H:%M:%S',
     ).dt.time
 
-    collisions.replace(value_aliases, inplace=True)
+    collisions = collisions.replace(to_replace=value_aliases)
 
     # convert easting, northings
     collisions['longitude'], collisions['latitude'] = convert_lonlat(

--- a/src/02-filter-data.py
+++ b/src/02-filter-data.py
@@ -57,7 +57,7 @@ def recalculate_severity(casualties, mode_of_travel):
         casualties
         [casualties['mode_of_travel'] == mode_of_travel]
         .groupby('collision_id')
-        .apply(accident_severity_counts)
+        .apply(accident_severity_counts, include_groups=False)
         .reset_index()
     )
 

--- a/src/app_functions.py
+++ b/src/app_functions.py
@@ -23,7 +23,7 @@ ENVIRONMENT = os.environ.get("ENVIRONMENT", "prod")
 def read_in_data(params: dict = DATA_PARAMETERS) -> tuple:
     """
     Function to read in different data depending on tolerance requests.
-    Reads from local if not on streamlit server, otherwise from google sheets.
+    Reads from local if not on streamlit server, otherwise from GCS.
     """
     if ENVIRONMENT == 'dev':
         junctions = pd.read_parquet(
@@ -39,13 +39,13 @@ def read_in_data(params: dict = DATA_PARAMETERS) -> tuple:
     else:
         conn = st.connection('gcs', type=FilesConnection)
         junctions = conn.read(
-            "lcc-app-data/2019-2023/junctions-tolerance=15.parquet",
+            "lcc-app-data/2020-2024/junctions-tolerance=15.parquet",
             input_format="parquet",
             engine='pyarrow',
             columns=params['junction_app_columns']
         )
         collisions = conn.read(
-            "lcc-app-data/2019-2023/collisions-tolerance=15.parquet",
+            "lcc-app-data/2020-2024/collisions-tolerance=15.parquet",
             input_format="parquet",
             engine='pyarrow',
             columns=params['collision_app_columns']


### PR DESCRIPTION
Updating the app with 2024 data. Notable changes:
- New severity categories, which have all been mapped to `serious` in the data:
     - Less Serious
     - Moderately Serious
     - Very Serious
 - Clear drop in the number of collisions - need to find out why this is the case. Number of collisions is lower than 2020, a covid year - see more below

Number of collisions by year:
```
year
2020    6268
2021    6782
2022    7229
2023    7062
2024    5231
```

Number of collisions by year and severity:
```
year  collision_severity
2020  fatal                   31
      serious               1222
      slight                5015
2021  fatal                   31
      serious               1382
      slight                5369
2022  fatal                   33
      serious               1642
      slight                5554
2023  fatal                   37
      serious               1583
      slight                5442
2024  fatal                   26
      serious               1137
      slight                4068
```